### PR TITLE
feat: add memory store as default cache backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@
 
 With Sails Stash, you can easily implement efficient caching for your Sails applications, enhancing performance and scalability without the need for complex setup.
 
-Sails Stash integrates seamlessly with your Sails project, providing a straightforward way to cache data using Redis. By leveraging Redis as a caching layer, you can optimize the retrieval of frequently accessed data, reducing database load and improving overall application performance.
+Sails Stash integrates seamlessly with your Sails project, providing a straightforward way to cache data. It works out of the box with an in-memory store for development, and can be easily configured to use Redis for production environments. By leveraging caching, you can optimize the retrieval of frequently accessed data, reducing database load and improving overall application performance.
 
 ## Features
 
 - Seamless integration with Sails projects
-- Efficient caching using Redis
+- **Zero-config memory store** for development (no Redis required!)
+- Optional Redis support for production environments
 - Improved performance and scalability
 - Simple setup and usage
 
@@ -19,30 +20,12 @@ You can install Sails Stash via npm:
 npm i sails-stash
 ```
 
-## Using Redis as store
-
-To use Redis as a cache store, install the `sails-redis` adapter
-
-```sh
-npm i sails-redis
-```
-
-### Setup the datastore
-
-```js
-// config/datastores.js
-...
-cache: {
-  adapter: 'sails-redis'
-  url: '<REDIS_URL>'
-}
-```
-
 ## Usage
 
-You can now cache values in your Sails actions.
+Sails Stash works out of the box with **no configuration required**. It uses an in-memory store by default, perfect for development:
 
 ```js
+// Works immediately after installation!
 await sails.cache.fetch(
   'posts',
   async function () {
@@ -51,6 +34,46 @@ await sails.cache.fetch(
   6000,
 )
 ```
+
+## Using Redis for Production
+
+When you're ready to deploy to production, you can optionally switch to Redis for persistent, distributed caching.
+
+### 1. Install the Redis adapter
+
+```sh
+npm i sails-redis
+```
+
+### 2. Setup the datastore
+
+```js
+// config/datastores.js
+module.exports.datastores = {
+  // ... other datastores
+
+  cache: {
+    adapter: 'sails-redis',
+    url: process.env.REDIS_URL,
+  },
+}
+```
+
+### 3. Configure Sails Stash to use Redis
+
+```js
+// config/local.js or config/env/production.js
+module.exports = {
+  cachestores: {
+    default: {
+      store: 'redis',
+      datastore: 'cache',
+    },
+  },
+}
+```
+
+That's it! Your application will now use Redis for caching in production while still using the memory store in development.
 
 Check out the [documentation](https://docs.sailscasts.com/stash) for more ways to setup and use Sails Stash.
 

--- a/lib/stores/cache-store.js
+++ b/lib/stores/cache-store.js
@@ -7,7 +7,7 @@ function CacheStore(sails) {
 
   this.sails = sails
   this.datastore =
-    sails.config.cachestores[sails.config.stash.cachestore].datastore
+    sails.config.cachestores[sails.config.stash.cachestore].datastore || null
   this.store = null
 }
 /**

--- a/lib/stores/memory-store.js
+++ b/lib/stores/memory-store.js
@@ -1,0 +1,140 @@
+const CacheStore = require('./cache-store')
+
+function MemoryStore(sails) {
+  CacheStore.call(this, sails)
+  this.cache = new Map()
+  this.cleanupInterval = null
+  this._startCleanup()
+}
+
+MemoryStore.prototype = Object.create(CacheStore.prototype)
+MemoryStore.prototype.constructor = MemoryStore
+
+MemoryStore.prototype._startCleanup = function () {
+  this.cleanupInterval = setInterval(() => {
+    const now = Date.now()
+    for (const [key, entry] of this.cache.entries()) {
+      if (entry.expiresAt && entry.expiresAt <= now) {
+        this.cache.delete(key)
+      }
+    }
+  }, 60000)
+
+  if (this.cleanupInterval.unref) {
+    this.cleanupInterval.unref()
+  }
+}
+
+MemoryStore.prototype._stopCleanup = function () {
+  if (this.cleanupInterval) {
+    clearInterval(this.cleanupInterval)
+    this.cleanupInterval = null
+  }
+}
+
+MemoryStore.prototype.getStore = async function () {
+  return this.cache
+}
+
+MemoryStore.prototype.get = async function (key, defaultValueOrCallback) {
+  const entry = this.cache.get(key)
+
+  if (!entry) {
+    if (typeof defaultValueOrCallback === 'function') {
+      return await defaultValueOrCallback()
+    }
+    return defaultValueOrCallback
+  }
+
+  if (entry.expiresAt && entry.expiresAt <= Date.now()) {
+    this.cache.delete(key)
+    if (typeof defaultValueOrCallback === 'function') {
+      return await defaultValueOrCallback()
+    }
+    return defaultValueOrCallback
+  }
+
+  return entry.value
+}
+
+MemoryStore.prototype.set = async function (key, value, ttlInSeconds) {
+  const entry = {
+    value,
+    expiresAt: ttlInSeconds ? Date.now() + ttlInSeconds * 1000 : null,
+  }
+  this.cache.set(key, entry)
+}
+
+MemoryStore.prototype.has = async function (key) {
+  const entry = this.cache.get(key)
+
+  if (!entry) {
+    return false
+  }
+
+  if (entry.expiresAt && entry.expiresAt <= Date.now()) {
+    this.cache.delete(key)
+    return false
+  }
+
+  return true
+}
+
+MemoryStore.prototype.delete = async function (key) {
+  if (Array.isArray(key)) {
+    let deletedCount = 0
+    for (const k of key) {
+      if (this.cache.delete(k)) {
+        deletedCount++
+      }
+    }
+    return deletedCount
+  }
+
+  return this.cache.delete(key) ? 1 : 0
+}
+
+MemoryStore.prototype.fetch = async function (
+  key,
+  defaultValueOrCallback,
+  ttlInSeconds,
+) {
+  const cacheHit = await this.get(key)
+  if (!cacheHit) {
+    let defaultValue
+    if (typeof defaultValueOrCallback === 'function') {
+      defaultValue = await defaultValueOrCallback()
+    } else {
+      defaultValue = defaultValueOrCallback
+    }
+    await this.set(key, defaultValue, ttlInSeconds)
+    return defaultValue
+  }
+  return cacheHit
+}
+
+MemoryStore.prototype.add = async function (key, value, ttlInSeconds) {
+  const exists = await this.has(key)
+  if (!exists) {
+    await this.set(key, value, ttlInSeconds)
+    return true
+  }
+  return false
+}
+
+MemoryStore.prototype.pull = async function (key) {
+  const value = await this.get(key)
+  await this.delete(key)
+  return value
+}
+
+MemoryStore.prototype.forever = async function (key, value) {
+  await this.set(key, value)
+}
+
+MemoryStore.prototype.destroy = async function () {
+  this.cache.clear()
+  this._stopCleanup()
+}
+
+module.exports = MemoryStore


### PR DESCRIPTION
This PR adds an in-memory cache store as the default backend for Sails Stash, making it work out of the box without requiring Redis setup.

Resolves #3

## Changes
- Added `MemoryStore` implementation with full cache API support
- Set memory store as the default in hook configuration
- Automatic cleanup of expired entries every 60 seconds
- Production warning when using memory store
- Updated README with zero-config usage example

## Features
- **Zero configuration** - Works immediately after installation
- **Full API compatibility** - Supports all cache methods (get, set, has, delete, fetch, add, pull, forever, destroy)
- **TTL support** - Handles expiration like Redis
- **Multiple key deletion** - Supports deleting arrays of keys
- **Dev-friendly** - Perfect for development environments

Users can still configure Redis for production by setting the store in their config.